### PR TITLE
better display on mobile

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,36 +3,16 @@
   <div class="wrapper">
 
     <div class="footer-col-wrapper">
-      <div class="footer-col  footer-col-1">
+      <div class="footer-col footer-col-all">
+        {% include logo.html %}
         <ul class="contact-list">
           <li>{{ site.title }}</li>
-          {% if site.twitter_username %}
-          <li>
-            <a href="https://twitter.com/{{ site.twitter_username }}">
-              <span class="icon  icon--twitter">
-                <svg viewBox="0 0 16 16">
-                  <path fill="#828282" d="M15.969,3.058c-0.586,0.26-1.217,0.436-1.878,0.515c0.675-0.405,1.194-1.045,1.438-1.809
-                  c-0.632,0.375-1.332,0.647-2.076,0.793c-0.596-0.636-1.446-1.033-2.387-1.033c-1.806,0-3.27,1.464-3.27,3.27 c0,0.256,0.029,0.506,0.085,0.745C5.163,5.404,2.753,4.102,1.14,2.124C0.859,2.607,0.698,3.168,0.698,3.767 c0,1.134,0.577,2.135,1.455,2.722C1.616,6.472,1.112,6.325,0.671,6.08c0,0.014,0,0.027,0,0.041c0,1.584,1.127,2.906,2.623,3.206 C3.02,9.402,2.731,9.442,2.433,9.442c-0.211,0-0.416-0.021-0.615-0.059c0.416,1.299,1.624,2.245,3.055,2.271 c-1.119,0.877-2.529,1.4-4.061,1.4c-0.264,0-0.524-0.015-0.78-0.046c1.447,0.928,3.166,1.469,5.013,1.469 c6.015,0,9.304-4.983,9.304-9.304c0-0.142-0.003-0.283-0.009-0.423C14.976,4.29,15.531,3.714,15.969,3.058z"/>
-                </svg>
-              </span>
-
-              <span class="username">{{ site.twitter_username }}</span>
-            </a>
-          </li>
-          {% endif %}
           <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
         </ul>
         <p class="terms">
           <a href="/tos">Terms</a> |
           <a href="http://www.google.com/intl/en/policies/privacy/">Privacy</a>
         </p>
-      </div>
-
-      <div class="footer-col  footer-col-2">
-      </div>
-
-      <div class="footer-col  footer-col-3">
-        {% include logo.html %}
       </div>
     </div>
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -131,6 +131,7 @@ code {
 }
 
 pre {
+    overflow-x: scroll;
     padding: 8px 12px;
 
     > code {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -40,6 +40,10 @@
         &:not(:first-child) {
             margin-left: 20px;
         }
+
+        @include media-query($on-palm) {
+            color: $brand-color;
+        }
     }
 
     @include media-query($on-palm) {
@@ -94,7 +98,7 @@
  */
 .site-footer {
     border-top: 1px solid $grey-color-light;
-    padding: $spacing-unit 0;
+    padding-top: $spacing-unit;
 }
 
 .footer-heading {
@@ -109,7 +113,6 @@
 }
 
 .footer-col-wrapper {
-    font-size: 15px;
     color: $grey-color;
     margin-left: -$spacing-unit / 2;
     @extend %clearfix;
@@ -136,8 +139,24 @@
     width:         calc(45% - (#{$spacing-unit} / 2));
 }
 
+.footer-col-all {
+    width: -webkit-calc(100% - (#{$spacing-unit} / 2));
+    width:         calc(100% - (#{$spacing-unit} / 2));
+}
+
 .logo {
   text-align: right;
+  float: right;
+  position: relative;
+  top: -10px;
+
+  @include media-query($on-palm) {
+      top: -15px;
+
+      svg {
+          width: 100px;
+      }
+  }
 }
 
 @include media-query($on-laptop) {

--- a/getting-started.md
+++ b/getting-started.md
@@ -8,7 +8,7 @@ To get started, we need to set up Dart SDK:
 
  - Install the [Dart SDK](https://www.dartlang.org/downloads/):
    - Mac: `brew tap dart-lang/dart && brew install dart --devel`
-   - Linux: See [https://www.dartlang.org/downloads/linux.html](https://www.dartlang.org/downloads/linux.html)
+   - Linux: See [www.dartlang.org/downloads/linux.html](https://www.dartlang.org/downloads/linux.html)
  - Ensure that the `dart` and `pub` executables are on your `PATH`.
 
 Once you have installed Dart SDK, create a new directory and add a


### PR DESCRIPTION
Some various tweaks so the docs display better on mobile:
- change code samples so they scroll horizontally, instead of the whole page scrolling horizontally when there are long samples on the page
- adjust the text color for the nav menu items, so menus aren't white on white on mobile
- tweak the footer margins; make the logo slightly smaller on mobile