### PR TITLE
Validate snippets

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,4 @@
+analyzer:
+  exclude:
+    - '_includes/**'
+    - '_layouts/**'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 _site
 .sass-cache
+
+# Dart ignores.
 .packages
+.pub/
 pubspec.lock
 packages
+example/*.dart

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 _site
 .sass-cache
+.packages
+pubspec.lock
+packages

--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,5 @@ markdown: kramdown
 kramdown:
   input: GFM
   hard_wrap: false
+
+exclude: [example, packages, tool]

--- a/example/readme.md
+++ b/example/readme.md
@@ -1,0 +1,1 @@
+Note: All Dart files in this directory are git ignored.

--- a/getting-started.md
+++ b/getting-started.md
@@ -23,6 +23,7 @@ Once you have installed Dart SDK, create a new directory and add a
 name: your_app_name
 dependencies:
   sky: any
+dev_dependencies:
   sky_tools: any
 ```
 
@@ -65,7 +66,7 @@ of the Android operating system.
    device, authorize your computer to access your device.
 
 Running a Flutter application
--------------------------
+-----------------------------
 
 The `sky` pub package includes a `sky_tool` script to assist in running Flutter
 applications inside the `SkyShell.apk` harness.  The `sky_tool` script expects

--- a/layout.md
+++ b/layout.md
@@ -3,6 +3,7 @@ layout: page
 title: Layout
 permalink: /layout/
 ---
+
 In Sky, widgets are rendered by render boxes. Render boxes are given
 constraints by their parent, and size themselves within those
 constraints. Constraints consist of minimum and maximum widths and

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,2 +1,5 @@
 name: flutter_github_io
 version: 0.0.1
+dev_dependencies:
+  path: any
+  sky: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,2 @@
+name: flutter_github_io
+version: 0.0.1

--- a/rendering.md
+++ b/rendering.md
@@ -243,6 +243,7 @@ A `RenderBox` subclass is required to implement the following contract:
   `RenderBox` nodes, then change the `setupParentData()` signature
   accordingly, to catch misuse of the method.)
 
+<!-- skip -->
 ```dart
   class FooParentData extends BoxParentData { ... }
 
@@ -395,7 +396,9 @@ working with the render tree.
 import 'package:sky/animation.dart';
 import 'package:sky/rendering.dart';
 
-scheduler.addPersistentFrameCallback((_) {
-  SkyBinding.instance.debugDumpRenderTree();
-});
+void main() {
+  scheduler.addPersistentFrameCallback((_) {
+    FlutterBinding.instance.debugDumpRenderTree();
+  });
+}
 ```

--- a/rendering.md
+++ b/rendering.md
@@ -3,6 +3,7 @@ layout: page
 title: Rendering
 permalink: /rendering/
 ---
+
 The Sky render tree is a low-level layout and painting system based on a
 retained tree of objects that inherit from [`RenderObject`](object.dart). Most
 developers using Sky will not need to interact directly with the rendering tree.

--- a/tool/extract.dart
+++ b/tool/extract.dart
@@ -1,0 +1,109 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Extract Dart snippets from the markdown documentation.
+void main(List<String> args) {
+  // Validate our cwd.
+  File pubspec = new File('pubspec.yaml');
+  if (!pubspec.existsSync()) {
+    fail('This tool must the run from the project root.');
+  }
+
+  // Remove any previously generated files.
+  clean();
+
+  // Traverse markdown files in the root.
+  List<File> markdownFiles = Directory.current.listSync().where((entity) {
+    return entity is File && entity.path.endsWith('.md');
+  }).toList();
+
+  markdownFiles.forEach(_processFile);
+}
+
+void _processFile(File file) {
+  print(file.path);
+
+  String name = p.basename(file.path);
+
+  // Look for ```dart sections.
+  String source = file.readAsStringSync();
+  List<String> lines = source.split('\n');
+
+  int index = 1;
+  int count = 0;
+
+  String lastComment;
+
+  while (index < lines.length) {
+    // Look for ```
+    if (lines[index].startsWith('```dart') && lastComment != 'skip') {
+      int startIndex = index + 1;
+      index++;
+      while (index < lines.length && !lines[index].startsWith('```')) {
+        index++;
+      }
+      _extract(name, ++count, startIndex, lines.sublist(startIndex, index),
+          includeSource: lastComment);
+    } else if (lines[index].startsWith('<!--')) {
+      int startIndex = index;
+      while (!lines[index].endsWith('-->')) {
+        index++;
+      }
+
+      lastComment = lines.sublist(startIndex, index + 1).join('\n');
+      lastComment = lastComment.substring(4);
+      lastComment = lastComment.substring(0, lastComment.length - 3).trim();
+    } else {
+      lastComment = null;
+    }
+
+    index++;
+  }
+}
+
+void _extract(String filename, int snippet, int startLine, List<String> lines,
+    {String includeSource}) {
+  String first = lines.first.trim();
+  bool hasImport = first.startsWith('import ');
+  // // TODO: Many of these should be analyzed as well.
+  // print('  skipping ${filename} line ${startLine}, no import statement');
+  // return;
+
+  String path =
+      'example/${filename.replaceAll('-', '_').replaceAll('.', '_')}_${snippet}.dart';
+
+  String source =
+    '// Extracted from ${filename} line ${startLine}.\n';
+
+  int adjust = 1;
+
+  if (!hasImport) {
+    source += "import 'package:sky/material.dart';\n";
+    adjust++;
+  }
+
+  if (includeSource != null) {
+    source += "${includeSource}\n";
+    adjust += includeSource.split('\n').length;
+  }
+
+  source +=
+    '${''.padRight(startLine - adjust, '\n')}'
+    '${lines.join('\n')}\n';
+
+  print('  extracting ${path} from line ${startLine}');
+  new File(path).writeAsStringSync(source);
+}
+
+void clean() {
+  Iterable<File> files = new Directory('example').listSync().where((entity) {
+    return entity is File && entity.path.endsWith('.dart');
+  });
+  files.forEach((file) => file.deleteSync());
+}
+
+void fail(String message) {
+  print(message);
+  exit(1);
+}

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Fast fail the script on failures.
+set -e
+
+# Extract Dart snippets from the markdown documentation.
+dart tool/extract.dart
+
+# Analyze the extracted Dart libraries.
+pub global activate tuneup
+pub global run tuneup check

--- a/tool/validate.dart
+++ b/tool/validate.dart
@@ -1,0 +1,5 @@
+
+/// Validate the Dart snippets in the markdown documentation.
+void main(List<String> args) {
+
+}

--- a/tool/validate.dart
+++ b/tool/validate.dart
@@ -1,5 +1,0 @@
-
-/// Validate the Dart snippets in the markdown documentation.
-void main(List<String> args) {
-
-}

--- a/tos.md
+++ b/tos.md
@@ -3,12 +3,12 @@ layout: page
 title: Terms of Service
 permalink: /tos/
 ---
+
 # Terms of Service
 
-The Flutter website (the "Website") is hosted by Google. By using and/or
+The Flutter website (the "Website") is hosted by Google. By using and / or
 visiting the Website, you consent to be bound by Google's general
-[Terms of Service][tos] and Google's general
-[Privacy Policy][pp].
+[Terms of Service][tos] and Google's general [Privacy Policy][pp].
 
 [tos]: http://www.google.com/accounts/TOS
 [pp]: http://www.google.com/intl/en/policies/privacy/

--- a/tutorial.md
+++ b/tutorial.md
@@ -4,6 +4,7 @@ title: Flutter Tutorial
 nav_title: Tutorial
 permalink: /tutorial/
 ---
+
 Flutter widgets are built using a functional-reactive framework, which takes
 inspiration from [React](http://facebook.github.io/react/). The central idea is
 that you build your UI out of components. Components describe what their view

--- a/tutorial.md
+++ b/tutorial.md
@@ -93,6 +93,7 @@ they consume the available space using the `flex` argument to
 To use this component, we simply create an instance of `MyToolBar` in a `build`
 function:
 
+<!-- skip -->
 ```dart
 import 'package:sky/widgets.dart';
 
@@ -187,6 +188,8 @@ class MyButton extends StatelessComponent {
   final Widget child;
   final Function onPressed;
 
+  BoxDecoration _decoration;
+
   Widget build(BuildContext context) {
     return new GestureDetector(
       onTap: onPressed,
@@ -207,6 +210,11 @@ uses `MyButton` provide an arbitrary `Widget` to put inside the button. For
 example, we can put an elaborate layout involving text and an image inside the
 button:
 
+<!--
+class MyButton extends IconButton {
+
+}
+-->
 ```dart
   Widget build(BuildContext context) {
     return new MyButton(
@@ -239,6 +247,11 @@ a checkbox. While the dialog is open, the user might check and uncheck the
 checkbox several times before closing the dialog and committing the final value
 of the checkbox to the underlying application data model.
 
+<!--
+class MyButton extends IconButton {
+  MyButton({onPressed}) : super(onPressed: onPressed);
+}
+-->
 ```dart
 class MyCheckbox extends StatelessComponent {
   MyCheckbox({ this.value, this.onChanged });
@@ -249,7 +262,7 @@ class MyCheckbox extends StatelessComponent {
   Widget build(BuildContext context) {
     Color color = value ? const Color(0xFF00FF00) : const Color(0xFF0000FF);
     return new GestureDetector(
-      onTap: () { onChanged(!value) },
+      onTap: () { onChanged(!value); },
       child: new Container(
         height: 25.0,
         width: 25.0,
@@ -383,12 +396,21 @@ only be unique among siblings. Because they are globally unique, a global key
 can be used to retrieve the state associated with a widget. Consider the
 following example:
 
+<!--
+class MyDialog extends StatefulComponent {
+  State createState() => null;
+}
+
+class MyButton extends IconButton {
+  MyButton({onPressed}) : super(onPressed: onPressed);
+}
+-->
 ```dart
 class MyComponentState extends State<MyDialog> {
   GlobalKey _scrollable = new GlobalKey();
 
   Widget build(BuildContext context) {
-    return Column([
+    return new Column([
       new MyButton(
         onPressed: () {
           (_scrollable.currentState as ScrollableState).scrollBy(10.0);
@@ -404,7 +426,7 @@ class MyComponentState extends State<MyDialog> {
             child: new Center(child: new Text('$i'))
           );
         }
-      );
+      )
     ]);
   }
 }
@@ -427,6 +449,7 @@ This can be quite useful in figuring out exactly what is going on when
 working with the widgets system. For this to work, you have to have
 launched your app with `runApp()`.
 
+<!-- skip -->
 ```dart
 debugDumpApp();
 ```

--- a/widgets.md
+++ b/widgets.md
@@ -4,6 +4,7 @@ title: Widget Gallery
 nav_title: Widgets
 permalink: /widgets/
 ---
+
 This page describes the widgets available in Flutter. These widgets are
 general-purpose and don't offer an opinion about the visual style of your app.
 
@@ -39,7 +40,7 @@ The direction along which the widgets are laid out is called the
 *main* direction and the other axis is called the *cross* direction.
 These flex widgets size themselves to the maximum size permitted by
 its parent, unless that would be infinite size, in which case they
-shrink-wrap their children. For details, see [flex.md](flex.md).
+shrink-wrap their children. For details, see [layout](layout/#flex).
 
 Each child of a flex widget is either *flexible* or *inflexible*.
 The flex first lays out its inflexible children and subtracts their

--- a/widgets.md
+++ b/widgets.md
@@ -40,7 +40,7 @@ The direction along which the widgets are laid out is called the
 *main* direction and the other axis is called the *cross* direction.
 These flex widgets size themselves to the maximum size permitted by
 its parent, unless that would be infinite size, in which case they
-shrink-wrap their children. For details, see [layout](layout/#flex).
+shrink-wrap their children. For details, see [layout](../layout/#flex).
 
 Each child of a flex widget is either *flexible* or *inflexible*.
 The flex first lays out its inflexible children and subtracts their


### PR DESCRIPTION
Validate the code snippets in the documentation. They drift out of date as the APIs get refactored; this will help keep them in sync.

- extract code snippets out into dart files in the `example/` dir
- add travis functionality to perform the extraction and analyze the code on PRs / commits
- add the ability to skip some dart snippets, or decorate them with hidden header code
- fix 1/2 dozen issues found in the snippets

There are 13 issues with the current snippets. We'll want to fix those issues or skip those snippets.