### PR TITLE
fix two analysis issues

### DIFF
--- a/rendering.md
+++ b/rendering.md
@@ -398,7 +398,7 @@ import 'package:flutter/rendering.dart';
 
 void main() {
   scheduler.addPersistentFrameCallback((_) {
-    FlutterBinding.instance.debugDumpRenderTree();
+    debugDumpRenderTree();
   });
 }
 ```

--- a/tutorial.md
+++ b/tutorial.md
@@ -217,7 +217,7 @@ class MyButton extends IconButton {
 ```dart
   Widget build(BuildContext context) {
     return new MyButton(
-      child: new ShrinkWrapWidth(
+      child: new IntrinsicWidth(
         child: new Row([
           new NetworkImage(src: 'thumbs-up.png', width: 25.0, height: 25.0),
           new Container(


### PR DESCRIPTION
Pull in a fix from https://github.com/flutter/flutter.github.io/pull/24; partially address #23.

There are still 3 remaining warnings, all to do with a `child:` param.
