### PR TITLE
Add missing parameter to itemBuilder callback

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -469,7 +469,7 @@ class _ShoppingListState extends State<ShoppingList> {
       body: new MaterialList<Product>(
         type: MaterialListType.oneLineWithAvatar,
         items: config.products,
-        itemBuilder: (BuildContext context, Product product) {
+        itemBuilder: (BuildContext context, Product product, int index) {
           return new ShoppingListItem(
             product: product,
             inCart: _shoppingCart.contains(product),


### PR DESCRIPTION
The ItemBuilder function-type alias specifies three arguments (BuildContext context, T item, int index). The proposed change adds the missing parameter which was causing the warning bellow and preventing app from running.

```
The argument type '(BuildContext, Product) → dynamic' cannot be assigned to the parameter type 'ItemBuilder'
```