### PR TITLE
Redirect samples index url to docs site

### DIFF
--- a/flutter_web/index.html
+++ b/flutter_web/index.html
@@ -12,5 +12,5 @@
     <link rel="canonical" href="https://flutter.github.io/samples/">
     <meta http-equiv="refresh" content="0; url=https://docs.flutter.dev/reference/learning-resources/?utm_source=flutter_github_io&utm_medium=Redirect&utm_content=meta_refresh" />
   </head>
-  <body>Please visit <a href='https://docs.flutter.dev/reference/learning-resources/?utm_source=flutter_github_io&utm_medium=Redirect&utm_content=click'>flutter.dev</a></body>
+  <body>Please visit the new samples page at <a href='https://docs.flutter.dev/reference/learning-resources/'>flutter.dev/reference/learning-resources</a></body>
 </html>

--- a/flutter_web/index.html
+++ b/flutter_web/index.html
@@ -10,7 +10,7 @@
       gtag('config', 'UA-67589403-8');
     </script>
     <link rel="canonical" href="https://flutter.github.io/samples/">
-    <meta http-equiv="refresh" content="0; url=https://flutter.github.io/samples/?utm_source=flutter_github_io&utm_medium=Redirect&utm_content=meta_refresh" />
+    <meta http-equiv="refresh" content="0; url=https://docs.flutter.dev/reference/learning-resources/?utm_source=flutter_github_io&utm_medium=Redirect&utm_content=meta_refresh" />
   </head>
-  <body>Please visit <a href='https://flutter.github.io/samples/?utm_source=flutter_github_io&utm_medium=Redirect&utm_content=click'>flutter.dev</a></body>
+  <body>Please visit <a href='https://docs.flutter.dev/reference/learning-resources/?utm_source=flutter_github_io&utm_medium=Redirect&utm_content=click'>flutter.dev</a></body>
 </html>


### PR DESCRIPTION
Set up a redirect from flutter.github.io/samples to the new page on the docs site.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
