### PR TITLE
update redirect link

### DIFF
--- a/flutter_web/index.html
+++ b/flutter_web/index.html
@@ -1,16 +1,16 @@
 <!DOCTYPE HTML>
 <html lang="en">
-  <head>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-67589403-8"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-67589403-8"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-      gtag('config', 'UA-67589403-8');
-    </script>
-    <link rel="canonical" href="https://flutter.github.io/samples/">
-    <meta http-equiv="refresh" content="0; url=https://flutter.github.io/samples/?utm_source=flutter_github_io&utm_medium=Redirect&utm_content=meta_refresh" />
-  </head>
-  <body>Please visit <a href='https://flutter.github.io/samples/?utm_source=flutter_github_io&utm_medium=Redirect&utm_content=click'>flutter.dev</a></body>
+    gtag('config', 'UA-67589403-8');
+  </script>
+  <link rel="canonical" href="https://flutter.github.io/samples/">
+  <meta http-equiv="refresh" content="0; url=https://docs.flutter.dev/reference/learning-resources/?utm_source=flutter_github_io&utm_medium=Redirect&utm_content=meta_refresh" />
+</head>
+<body>Please visit the new samples page at <a href='https://docs.flutter.dev/reference/learning-resources/'>flutter.dev/reference/learning-resources</a></body>
 </html>


### PR DESCRIPTION
Redirects from the Visual Samples Index gh-pages to it's replacement on docs.flutter.dev. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

